### PR TITLE
Fixed #95. Updated Footer links. Added social icons to menu footer.

### DIFF
--- a/layouts/partials/menu-footer.html
+++ b/layouts/partials/menu-footer.html
@@ -1,14 +1,21 @@
 <center>
     <!-- Place this tag where you want the button to render. -->
-    <a class="github-button" href="https://github.com/opensds/opensds/archive/master.zip" data-icon="octicon-cloud-download" aria-label="Download opensds/opensds on GitHub">Download</a>
+    <a class="github-button" href="https://github.com/sodafoundation/releases/archive/v1.0.0.zip" data-icon="octicon-cloud-download" aria-label="Download Faroe Release v1.0.0 GitHub">Download</a>
 
     <!-- Place this tag where you want the button to render. -->
-    <a class="github-button" href="https://github.com/opensds/opensds/" data-icon="octicon-star" data-show-count="true" aria-label="Star opensds/opensds on GitHub">Star</a>
+    <a class="github-button" href="https://github.com/sodafoundation/api/" data-icon="octicon-star" data-show-count="true" aria-label="Star sodafoundation/api on GitHub">Star</a>
 
     <!-- Place this tag where you want the button to render. -->
-    <a class="github-button" href="https://github.com/opensds/opensds/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork opensds/opensds on GitHub">Fork</a>
+    <a class="github-button" href="https://github.com/sodafoundation/api/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork sodafoundation/api on GitHub">Fork</a>
 
     <p>Built with <a href="https://github.com/matcornic/hugo-theme-learn"><i class="fas fa-heart"></i></a> from <a href="https://getgrav.org" target="_blank">Grav</a> and <a href="https://gohugo.io/" target="_blank">Hugo</a></p>
 </center>
+<div id="menu-footer-social-links-container">
+    <a class="footer-social-links" title="Join SODA Foundation" href="https://sodafoundation.io/the-foundation/join/" target="_blank"><i class="fas fa-link fa-fw fa-2x"></i></a>  
+    <a class="footer-social-links" title="SODA Foundation Slack" href="https://sodafoundation.io/slack" target="_blank"><i class="fab fa-slack fa-2x"></i></a>  
+    <a class="footer-social-links" title="SODA Foundation Twitter" href="https://twitter.com/sodafoundation" target="_blank"><i class="fab fa-twitter fa-2x"></i></a>
+    <a class="footer-social-links" title="SODA Foundation Mailing List" href="https://lists.sodafoundation.io" target="_blank"><i class="fas fa-envelope fa-2x"></i></a>    
+</div>
+
 <!-- Place this tag in your head or just before your close body tag. -->
 <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -94,6 +94,7 @@
 {{ define "section-tree-nav" }}
 {{ $showvisitedlinks := .showvisitedlinks }}
 {{ $currentNode := .currentnode }}
+{{ $parent := .page.Parent }}
  {{with .sect}}
   {{if .IsSection}}
     {{safeHTML .Params.head}}
@@ -118,7 +119,7 @@
           {{ end }}
       </a>
       
-      {{ if ne $numberOfPages 0 }}
+      {{ if and (ne $numberOfPages 0) (.IsAncestor $currentNode) }}
         
         <ul>
           {{ $currentNode.Scratch.Set "pages" .Pages }}

--- a/static/css/theme-opensds.css
+++ b/static/css/theme-opensds.css
@@ -128,3 +128,10 @@ a:hover {
 #sidebar #shortcuts h3{
     color: #f3f3f3 !important;
 }
+
+div#menu-footer-social-links-container{
+    margin: 1rem 0 0 3rem;
+}
+a.footer-social-links{
+    padding: 0.35rem;
+}


### PR DESCRIPTION

**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR does the follwing:
- Fixes #95 : Currently the children of menu items are all displayed in the sidebar menu. This PR shows only the parent in the sidebar menu and displays the children only when the parent menu item is active.
- Added SODA Foundation social icons to the sidebar menu footer.
- Fixed the GitHub links for Download, Star and Fork from opensds to sodafoundation.

**Which issue(s) this PR fixes**:
Fixes #95 

**Test Report Added?**:
/kind TESTED


**Test Report**:
Please check the Deploy preview.
**Top level menu items only**
![image](https://user-images.githubusercontent.com/19162717/91853552-fb56e880-ec7f-11ea-9273-d74a9d3b1a8b.png)

**Show children only when parent is active.**
![image](https://user-images.githubusercontent.com/19162717/91853571-0578e700-ec80-11ea-9a48-0fd73eca8392.png)

**Footer Social Icons**
![image](https://user-images.githubusercontent.com/19162717/91853687-31946800-ec80-11ea-8192-d6c1052f44e1.png)


**Special notes for your reviewer**:
