### PR TITLE
docs(quickstart): Improve README formatting

### DIFF
--- a/content/soda-gettingstarted/quickstart.md
+++ b/content/soda-gettingstarted/quickstart.md
@@ -8,70 +8,90 @@ This is a quickstart guide for users and new contributors to try and get familia
 
 ***Note**: *At present, this document also provides the installation steps to try out older OpenSDS releases. Soon, the support for old opensds releases shall be removed.**
 
-To have more magement control on the installaton cofigurations,  or to try out various configurations refer a detailed installation guide [here](/soda-gettingstarted/installation)
+To have more control of the installaton cofigurations, or try out various configurations refer a detailed installation guide [here](/soda-gettingstarted/installation)
 
 ## Quick Installation and experience of SODA releases
 ### Install SODA v1.0.0 Faroe Release Jun 2020
+
 Quick installation from SODA Faroe Release:
 
- - **Prerequisite**
-	 - OS: Ubuntu 16.04 or Ubuntu 18.04
-	 - `root` user rights is REQUIRED 
-    -   Make sure the following packages are installed or use the steps to install them.
-    - Install Basic Dependency:
-	    - apt-get update && apt-get install -y git make curl wget libltdl7 libseccomp2 libffi-dev gawk
-	    
-   - Install Docker
-   	 - For Ubuntu 16.04:
-	    - wget **[https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb](https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb)**
-	
-	 - For Ubuntu 18.04:
-	    - wget **[https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb](https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb)**
-	    
-    - dpkg -i docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb
-    - Install docker-compose:
-	    -   curl -L https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
-		-   chmod +x /usr/local/bin/docker-compose
-    -   Required golang version: 1.13.x
-	    -   Run following command `go version` and check the version
-	    -   If the required version is not installed on the system, install golang,1.13.9 using:
-		   - wget **[https://storage.googleapis.com/golang/go1.13.9.linux-amd64.tar.gz](https://storage.googleapis.com/golang/go1.13.9.linux-amd64.tar.gz)**
-		- tar -C /usr/local -xzf go1.13.9.linux-amd64.tar.gz
-		- echo export PATH=$PATH:/usr/local/go/bin >> /etc/profile
-		- echo export GOPATH=$HOME/gopath >> /etc/profile
-		- source /etc/profile
+This procedure applies to Ubuntu 16.04 and 18.04 Linux distributions.
 
- - **Get and Install Release Binaries**
-	 - wget  **[https://github.com/sodafoundation/installer/releases/download/v1.0.0/installer-v1.0.0.tar.gz](https://github.com/sodafoundation/installer/releases/download/v1.0.0/installer-v1.0.0.tar.gz)**
- **OR** Download the installer binaries from  
- [https://github.com/sodafoundation/installer/releases/tag/v1.0.0](https://github.com/sodafoundation/installer/releases/tag/v1.0.0)
-
-	 - tar xvzf installer-v1.0.0.tar.gz
-	 - cd installer-v1.0.0/ansible/
-	 - chmod +x ./install_ansible.sh && ./install_ansible.sh
-	 - ansible --version # Ansible version 2.4.x is required
-	 - The HOST_IP need to be set to the real_host_ip of your host (ex: 192.168.1.10 or 127.0.0.1 for localhost)
-		 - export HOST_IP = <your_real_host_ip>
-		 - vim group_vars/common.yml # Modify `host_ip` address if needed
-
- - **Run the installer**
-	 - ansible-playbook site.yml -i local.hosts
-	 - Note: If you want to clean up and test again, run
-		 - ansible-playbook clean.yml -i local.hosts -vvv
-	 - and then run:
-		 - ansible-playbook site.yml -i local.hosts
- -   **How to do a quick test**
-		- Open Your Browser and use the http://< actual host ip>:8088 to access the SODA Dashboard
-    (This IP should be the IP Address of the host if you have updated the config file) Ex: [http://127.0.0.1:8088](http://127.0.0.1:8088)
-  
-	 - Use admin/opensds@123 credentials to login
-     -   You will login to the UI Dashboard and you can verify the features through various menu options
-
-
-
-### Install SODA v0.20.0 Elba Release Apr 2020
- - Elba Release (First Release of SODA) : Refer the "How to use the Release" section of [Elba Release Notes](https://github.com/sodafoundation/releases/releases/tag/v0.20.0)
+- **Prerequisite**
  
+   - Get superuser priviledges:
+    
+      `sudo -s`
+    
+    - Install Basic Dependencies:
+      
+      `apt-get update && apt-get install -y git make curl wget libltdl7 libseccomp2 libffi-dev gawk`
+	    
+     - Install Docker:
+       - Ubuntu 16.04:
 
-ATTN: We are currently not supporting the older versions before Elba. However, if you have specific reasons to use older versions, please contact at #general  slack channel of [soda foundation slack](https://sodafoundation.io/slack)
+       `wget https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb && dpkg -i docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb`
+	
+       - Ubuntu 18.04:
+
+       `wget https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb && dpkg -i docker-ce_18.06.1~ce~3-0~ubuntu_amd64.deb`
+    
+    - Install docker-compose:
+
+      `curl -L https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose`
+	
+    - Check golang version is at least 1.13.x
+    
+      `go version`
+      
+    - Otherwise install golang 1.13.9:
+      
+     `wget https://storage.googleapis.com/golang/go1.13.9.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.13.9.linux-amd64.tar.gz && echo export PATH=$PATH:/usr/local/go/bin >> /etc/profile && echo export GOPATH=$HOME/gopath >> /etc/profile && source /etc/profile`
+
+ - **Procedure**
+ 
+     - Prepare the installer:
+     
+      `wget https://github.com/sodafoundation/installer/releases/download/v1.0.0/installer-v1.0.0.tar.gz && tar xvzf installer-v1.0.0.tar.gz && cd installer-v1.0.0/ansible/ && chmod +x ./install_ansible.sh && ./install_ansible.sh`
+         
+     - Confirm Ansible version 2.4.x or later is installed:
+      
+      `ansible --version`
+
+     - The HOST_IP need to be set to the real_host_ip of your host (ex: 192.168.1.10 or 127.0.0.1 for localhost):
+      
+      `ip addr | grep inet`
+      
+      `export HOST_IP = <your_real_host_ip>`
+      
+      - Modify `host_ip`in YAML file:
+      
+      `vim group_vars/common.yml`
+
+      - Run the installer:
+      
+      `ansible-playbook site.yml -i local.hosts`
+      
+      - Repeat the above command several times if Ansible fails to find unarchive command (see https://github.com/ansible/ansible/issues/35645#issuecomment-402207861) 
+      
+      - You can also run a clean install if desired:
+      
+      `ansible-playbook clean.yml -i local.hosts -vvv &&& ansible-playbook site.yml -i local.hosts`
+      
+ -   **How to do a quick test**
+
+      - Open Your Browser and use the http://< actual host ip>:8088 to access the SODA Dashboard (this IP should be the IP Address of the host if you have updated the config file) Example: [http://127.0.0.1:8088](http://127.0.0.1:8088)
+  
+      - Use admin/opensds@123 credentials to login
+      
+      - You will login to the UI Dashboard and you can verify the features through various menu options
+
+
+### Previous Release
+
+**Install SODA v0.20.0 Elba Release Apr 2020**
+
+- Elba Release (First Release of SODA) : Refer the "How to use the Release" section of [Elba Release Notes](https://github.com/sodafoundation/releases/releases/tag/v0.20.0) 
+
+Note: We are currently not supporting the older versions before Elba. However, if you have specific reasons to use older versions, please contact at #general  slack channel of [soda foundation slack](https://sodafoundation.io/slack)
 


### PR DESCRIPTION
This PR introduces some improved formatting for the README:
- Combine multi-line commands into single-line commands for quicker installs
- Format commands with command-markup

I also encountered an ansible bug several times:
```
TASK [common : download and extract the api release tarball if not exists] ***********************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to find handler for \"/tmp/ansible_5OeE7o/soda-api-v1.0.0-linux-amd64.tar.gz\". Make sure the
 required command to extract the file is installed. Command \"/bin/tar\" could not handle archive. Command \"/usr/bin/unzip\" could not handle archive."}
        to retry, use: --limit @/home/vagrant/installer-v1.0.0/ansible/site.retry
```
I documented the workaround (see: https://github.com/ansible/ansible/issues/35645#issuecomment-402207861).

I also had another ansible error `ERROR: keystone didn't come up. Aborti
ng..."]}` but that is not documentation issue.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
/kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:

Tested on `generic/ubuntu1804` vagrant box.
