### PR TITLE
Update SODA Docs baseurl. Fixes broken search

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://soda-docs.netlify.com/"
+baseURL = "https://soda-docs.netlify.app/"
 languageCode = "en-US"
 defaultContentLanguage = "en"
 googleAnalytics = "UA-138679091-1"


### PR DESCRIPTION
Possible fix for broken search


**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR updates the baseurl to match the updated netlify domain from .com to .app.
This will possibly fix the issue of site wide search not working. 

**Which issue(s) this PR fixes**:
Fixes #108 

**Test Report Added?**:

 /kind TESTED

**Test Report**:
~~We can check the deploy preview if this works.~~
Please use the search box in the deploy preview [here](https://deploy-preview-136--soda-docs.netlify.app/)
The baseurl has to be updated nonetheless.

**Special notes for your reviewer**:
